### PR TITLE
Update test to fail on changing a field with an array value

### DIFF
--- a/src/form.spec.ts
+++ b/src/form.spec.ts
@@ -376,10 +376,21 @@ describe(Form, () => {
 
   describe('reseting', () => {
     it('resets fields', () => {
-      const form = createForm();
+      const form = createForm({
+        value: {
+          emails: ['bye@example.com', 'stay@example.com'],
+        }
+      });
       form.fields.name.onChange('hello');
+      form.fields.emails.onChange([
+        'hello@example.com', 'stay@example.com'
+      ]);
       form.reset();
       expect(form.changes).toEqual({});
+      expect(form.fields.name.value).toEqual('');
+      expect(form.fields.emails.value).toEqual([
+        'bye@example.com', 'stay@example.com'
+      ]);
     });
 
     it('resets error', async () => {


### PR DESCRIPTION
Changes a test to highlight a possible bug in the lib;
Changing a field with an array in it and resetting the form leads to the wrong value in `fields.<myField>`.

The reason seems to be that the fields `reset` method resets the subfields, which contain the incorrect `originalValue`.

For example, for a field `foo` with value `['bar', 'baz']` and changes `['new', 'baz']` the following happens when `foo.reset()` is called:

- In `FieldImplementation#reset` for `foo`:
  - `foo` gets reset to the correct original value (['new', 'baz']) (`this.value = this.#originalValue;`)
  - The first subfield is being reset (`this.subfields.forEach((e) => e.reset());`):
    - ! The subfield `foo[0]` contains the original value `new` (Instead of the expected `bar`)
      - ! `foo[0].onChange('new')` gets called, which sets `foo[0] = 'new'`, undoing the correct reset of `foo` itself in the first step
  - The second subfield is being reset, but as it didnt change it does not matter here
  
A naive fix would be to ignore the `subfields` for an array of base types like strings and numbers, as the reset on `foo` itself is doing the correct thing, before the subfields are handled.
I don't know however the implications of such a fix for your other features.