### PR TITLE
Update Github Actions ... actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,10 +9,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: '16.x'
+          node-version: '24.x'
           cache: yarn
       - name: Install Dependencies
         run: yarn install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,10 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: '16.x'
+          node-version: '24.x'
           registry-url: https://registry.npmjs.org/
           cache: yarn
       - run: yarn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: '16.x'
+          node-version: '24.x'
           cache: 'yarn'
       - name: Install Dependencies
         run: yarn install


### PR DESCRIPTION
Update to `actions/checkout@v6`, `actions/setup-node@v6`, and current Node.js LTS v24 to get rid of the CI errors in #43.