### PR TITLE
Fix: preserve nullable nested objects

### DIFF
--- a/src/field.ts
+++ b/src/field.ts
@@ -11,7 +11,7 @@ export type MappedFields<T> = {
     ? number extends NonNullable<T[P]>['length']
       ? FieldSet<NonNullable<T[P]>[0]>
       : Field<T[P]>
-    : T[P] extends Record<string, unknown> | undefined | null
+    : T[P] extends Record<string, unknown>
     ? NestedField<NonNullable<T[P]>>
     : Field<T[P]>;
 };

--- a/src/field.ts
+++ b/src/field.ts
@@ -11,7 +11,7 @@ export type MappedFields<T> = {
     ? number extends NonNullable<T[P]>['length']
       ? FieldSet<NonNullable<T[P]>[0]>
       : Field<T[P]>
-    : T[P] extends Record<string, unknown>
+    : T[P] extends Record<string, unknown> | undefined
     ? NestedField<NonNullable<T[P]>>
     : Field<T[P]>;
 };

--- a/src/test/types.spec.ts
+++ b/src/test/types.spec.ts
@@ -50,4 +50,10 @@ describe('MappedFields', () => {
 
     expect([_value, _hasFieldSetShape]).toEqual([true, true]);
   });
+
+  it('preserves null on nested object fields', () => {
+    type TestField = MappedFields<{ test: { foo: string } | null }>['test'];
+    const _mustAcceptNull: TestField['value'] = null;
+    void _mustAcceptNull;
+  });
 });


### PR DESCRIPTION
With a shape like that in the form:
```tsx
const form2 = useForm<{ test: { foo: string } | null }>({
    model: { test: null },
  });

form2.fields.test;
```

the `test` field has incorrect type:

<img width="639" height="145" alt="image" src="https://github.com/user-attachments/assets/3f8b6d05-eebd-4fb1-a659-53c4414e71f4" />

instead of declared:
```ts
{ foo: string } | null
```
  
 